### PR TITLE
upgrade golang add additional clients

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: donseba # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,56 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Require: The version of golangci-lint to use.
+          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
+          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
+          version: latest
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          #
+          # Note: By default, the `.golangci.yml` file should be at the root of the repository.
+          # The location of the configuration file can be changed by using `--config=`
+          # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0
+          args: --out-format=colored-line-number
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true, then all caching functionality will be completely disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true, then the action won't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true, then the action won't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true
+
+          # Optional: The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+          # install-mode: "goinstall"

--- a/client/cdnjs/cdnjs.go
+++ b/client/cdnjs/cdnjs.go
@@ -3,10 +3,10 @@ package cdnjs
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"github.com/donseba/go-importmap/library"
 	"net/http"
+
+	"github.com/donseba/go-importmap/library"
 )
 
 var (
@@ -57,7 +57,7 @@ func (c *Client) FetchPackageFiles(ctx context.Context, name, version string) (l
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", errors.New(fmt.Sprintf("client api responded with code %d", resp.StatusCode))
+		return nil, "", fmt.Errorf("client api responded with code %d", resp.StatusCode)
 	}
 
 	var sr SearchResponse

--- a/client/cdnjs/cdnjs_test.go
+++ b/client/cdnjs/cdnjs_test.go
@@ -1,13 +1,11 @@
 package cdnjs
 
 import (
-	"context"
 	"fmt"
 	"testing"
 )
 
 func TestClient_Search(t *testing.T) {
-	ctx := context.TODO()
 	cs := New()
 
 	var tests = []struct {
@@ -23,7 +21,7 @@ func TestClient_Search(t *testing.T) {
 	for _, tt := range tests {
 		testName := fmt.Sprintf("%s,%s,%s", tt.name, tt.version, tt.filename)
 		t.Run(testName, func(t *testing.T) {
-			p, _, err := cs.FetchPackageFiles(ctx, tt.name, tt.version)
+			p, _, err := cs.FetchPackageFiles(t.Context(), tt.name, tt.version)
 			if err != nil {
 				t.Error(err)
 			}

--- a/client/esmsh/esmsh.go
+++ b/client/esmsh/esmsh.go
@@ -1,0 +1,95 @@
+package esmsh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+
+	"github.com/donseba/go-importmap/library"
+)
+
+var (
+	defaultApiBaseURL = "https://esm.sh/"
+)
+
+// Client holds configuration for esm.sh requests.
+type Client struct {
+	apiBaseURL string
+}
+
+// New creates a new esm.sh client.
+func New() *Client {
+	return &Client{
+		apiBaseURL: defaultApiBaseURL,
+	}
+}
+
+// FetchPackageFiles retrieves package metadata from esm.sh.
+// It calls the ?meta endpoint, then parses the returned JavaScript snippet to extract the version
+// and the main export file URL. It returns a single file in the library.Files slice.
+func (c *Client) FetchPackageFiles(ctx context.Context, name, version string) (library.Files, string, error) {
+	// If a version is provided, use it; otherwise, let esm.sh resolve the latest version.
+	var pkgID string
+	if version != "" {
+		pkgID = fmt.Sprintf("%s@%s", name, version)
+	} else {
+		pkgID = name
+	}
+
+	// esm.sh meta endpoint returns a JavaScript snippet
+	metaURL := fmt.Sprintf("%s%s?meta", c.apiBaseURL, pkgID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metaURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("esm.sh meta API responded with code %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	text := string(body)
+
+	// Extract version from the leading comment.
+	// Expected format: "/* esm.sh - bootstrap@5.3.3 */"
+	reVersion := regexp.MustCompile(`/\*\s*esm\.sh\s*-\s*` + regexp.QuoteMeta(name) + `@([^\s*]+)`)
+	matches := reVersion.FindStringSubmatch(text)
+	if len(matches) < 2 {
+		return nil, "", errors.New("failed to parse version from esm.sh meta output")
+	}
+	parsedVersion := matches[1]
+
+	// Extract file URL from the export statement.
+	// Expected export line: export * from "/bootstrap@5.3.3/es2022/bootstrap.mjs";
+	reExport := regexp.MustCompile(`export\s+\*\s+from\s+["'](\/` + regexp.QuoteMeta(name) + `@[^"']+)["']`)
+	matches = reExport.FindStringSubmatch(text)
+	if len(matches) < 2 {
+		return nil, "", errors.New("failed to parse export file URL from esm.sh meta output")
+	}
+	filePath := matches[1]
+
+	// Construct the full file URL.
+	// esm.sh URLs are absolute, so we prepend the API base URL (ensuring no double slash).
+	fileURL := c.apiBaseURL[:len(c.apiBaseURL)-1] + filePath
+
+	file := library.File{
+		Type:      library.ExtractFileType(fileURL),
+		Path:      fileURL,
+		LocalPath: filePath,
+	}
+	files := library.Files{file}
+
+	return files, parsedVersion, nil
+}

--- a/client/esmsh/esmsh_test.go
+++ b/client/esmsh/esmsh_test.go
@@ -1,4 +1,4 @@
-package jsdelivr
+package esmsh
 
 import (
 	"encoding/json"

--- a/client/jsdelivr/jsdelivr.go
+++ b/client/jsdelivr/jsdelivr.go
@@ -3,11 +3,11 @@ package jsdelivr
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"github.com/donseba/go-importmap/library"
 	"net/http"
 	"strings"
+
+	"github.com/donseba/go-importmap/library"
 )
 
 var (
@@ -76,7 +76,7 @@ func (c *Client) FetchPackageFiles(ctx context.Context, name, version string) (l
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", errors.New(fmt.Sprintf("client api responded with code %d", resp.StatusCode))
+		return nil, "", fmt.Errorf("client api responded with code %d", resp.StatusCode)
 	}
 
 	var sr SearchResponse
@@ -113,7 +113,7 @@ func (c *Client) FetchPackageFiles(ctx context.Context, name, version string) (l
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", errors.New(fmt.Sprintf("client api responded with code %d", resp.StatusCode))
+		return nil, "", fmt.Errorf("client api responded with code %d", resp.StatusCode)
 	}
 
 	var pr PackageResponse

--- a/client/raw/raw.go
+++ b/client/raw/raw.go
@@ -2,18 +2,33 @@ package raw
 
 import (
 	"context"
+	"errors"
 
 	"github.com/donseba/go-importmap/library"
 )
 
-type (
-	Client struct{}
-)
-
-func New() *Client {
-	return &Client{}
+// Provider is a raw URL provider.
+// It implements the Provider interface.
+type Provider struct {
+	URL string
 }
 
-func (c *Client) Package(ctx context.Context, p library.Package) (string, error) {
-	return p.Raw, nil
+// New creates a new raw provider with the given URL.
+func New(url string) *Provider {
+	return &Provider{URL: url}
+}
+
+// FetchPackageFiles returns a single file with the raw URL.
+// The version is passed through unchanged.
+func (p *Provider) FetchPackageFiles(ctx context.Context, name, version string) (library.Files, string, error) {
+	if p.URL == "" {
+		return nil, "", errors.New("raw provider URL is empty")
+	}
+
+	file := library.File{
+		Type:      library.ExtractFileType(p.URL),
+		Path:      p.URL,
+		LocalPath: name,
+	}
+	return library.Files{file}, version, nil
 }

--- a/client/raw/raw_test.go
+++ b/client/raw/raw_test.go
@@ -1,4 +1,4 @@
-package jsdelivr
+package raw
 
 import (
 	"encoding/json"
@@ -6,15 +6,15 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	cdn := New()
+	cdn := New("https://unpkg.com/browse/htmx.org@1.9.10/dist/htmx.min.js")
 
-	f, v, err := cdn.FetchPackageFiles(t.Context(), "bootstrap", "5.3.3")
+	f, v, err := cdn.FetchPackageFiles(t.Context(), "htmx.org", "1.9.10")
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	if v != "5.3.3" {
+	if v != "1.9.10" {
 		t.Error("version mismatch")
 	}
 

--- a/client/skypack/skypack.go
+++ b/client/skypack/skypack.go
@@ -1,0 +1,127 @@
+package skypack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/donseba/go-importmap/library"
+)
+
+var (
+	defaultPackageApiBaseURL = "https://api.skypack.dev/v1/package/"
+	defaultBrowseApiBaseURL  = "https://api.skypack.dev/v1/browse/"
+	defaultCdnBaseURL        = "https://cdn.skypack.dev/"
+)
+
+// Client holds configuration for Skypack requests.
+type Client struct {
+	packageApiBaseURL string
+	browseApiBaseURL  string
+	cdnBaseURL        string
+}
+
+// PackageResponse represents the response structure from /v1/package/{name}.
+type PackageResponse struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// BrowseResponse represents the response structure from /v1/browse/{name}/{version}.
+type BrowseResponse struct {
+	Files []FileInfo `json:"files"`
+}
+
+// FileInfo represents individual file information in the browse response.
+type FileInfo struct {
+	Name   string  `json:"name"`
+	SizeKB float64 `json:"sizeKB"`
+	URL    string  `json:"url"`
+}
+
+// New creates a new Skypack client.
+func New() *Client {
+	return &Client{
+		packageApiBaseURL: defaultPackageApiBaseURL,
+		browseApiBaseURL:  defaultBrowseApiBaseURL,
+		cdnBaseURL:        defaultCdnBaseURL,
+	}
+}
+
+// FetchPackageFiles retrieves package metadata and file list from Skypack.
+// It first calls the package endpoint to determine the package version (if not explicitly provided)
+// and then calls the browse endpoint to retrieve the list of files.
+func (c *Client) FetchPackageFiles(ctx context.Context, name, version string) (library.Files, string, error) {
+	// Get package metadata from /v1/package/{name}
+	packageURL := c.packageApiBaseURL + name
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, packageURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("Skypack package API responded with code %d", resp.StatusCode)
+	}
+
+	var pr PackageResponse
+	if err = json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return nil, "", err
+	}
+
+	// Determine which version to use.
+	useVersion := pr.Version
+	if version != "" && version != useVersion {
+		useVersion = version
+	}
+
+	// Get file list from /v1/browse/{name}/{version}
+	browseURL := fmt.Sprintf("%s%s/%s", c.browseApiBaseURL, name, useVersion)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, browseURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("skypack browse API responded with code %d", resp.StatusCode)
+	}
+
+	var br BrowseResponse
+	if err = json.NewDecoder(resp.Body).Decode(&br); err != nil {
+		return nil, "", err
+	}
+
+	var files library.Files
+	for _, fileInfo := range br.Files {
+		// Construct a file entry using the URL returned in the response.
+		files = append(files, library.File{
+			Type:      library.ExtractFileType(fileInfo.Name),
+			Path:      fileInfo.URL,
+			LocalPath: fileInfo.Name,
+		})
+	}
+
+	// Fallback: If no files were returned, use the package entry point.
+	if len(files) == 0 {
+		fallbackURL := c.cdnBaseURL + name + "@" + useVersion
+		files = append(files, library.File{
+			Type:      library.ExtractFileType(fallbackURL),
+			Path:      fallbackURL,
+			LocalPath: name,
+		})
+	}
+
+	return files, useVersion, nil
+}

--- a/client/skypack/skypack_test.go
+++ b/client/skypack/skypack_test.go
@@ -1,4 +1,4 @@
-package jsdelivr
+package skypack
 
 import (
 	"encoding/json"
@@ -8,14 +8,14 @@ import (
 func TestNew(t *testing.T) {
 	cdn := New()
 
-	f, v, err := cdn.FetchPackageFiles(t.Context(), "bootstrap", "5.3.3")
+	f, v, err := cdn.FetchPackageFiles(t.Context(), "bootstrap", "5.1.3")
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	if v != "5.3.3" {
-		t.Error("version mismatch")
+	if v != "5.1.3" {
+		t.Errorf("version mismatch want 5.1.3 got %s", v)
 	}
 
 	if len(f) == 0 {

--- a/client/unpkg/unpkg.go
+++ b/client/unpkg/unpkg.go
@@ -1,0 +1,129 @@
+package unpkg
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/donseba/go-importmap/library"
+)
+
+var (
+	defaultApiBaseURL = "https://unpkg.com/%s@%s/?meta" // Package name + version
+	defaultCdnBaseURL = "https://unpkg.com/%s@%s/"      // Base CDN URL
+)
+
+type (
+	Client struct{}
+
+	UnpkgMetaResponse struct {
+		Type  string             `json:"type"`
+		Path  string             `json:"path"`
+		Files []UnpkgFileListing `json:"files"`
+	}
+
+	UnpkgFileListing struct {
+		Path string `json:"path"`
+		Type string `json:"type"`
+	}
+)
+
+func New() *Client {
+	return &Client{}
+}
+
+func (c *Client) FetchPackageFiles(ctx context.Context, name, version string) (library.Files, string, error) {
+	// Resolve latest version if not specified
+	if version == "" {
+		versionResp, err := c.getLatestVersion(ctx, name)
+		if err != nil {
+			return nil, "", err
+		}
+		version = versionResp
+	}
+
+	// Get file listing from Unpkg's meta API
+	metaUrl := fmt.Sprintf(defaultApiBaseURL, name, version)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metaUrl, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("unpkg API responded with status %d", resp.StatusCode)
+	}
+
+	var meta UnpkgMetaResponse
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		return nil, "", err
+	}
+
+	// Build base CDN URL
+	basePath := fmt.Sprintf(defaultCdnBaseURL, name, version)
+
+	// Recursively collect all files
+	var files library.Files
+	c.walkFiles(meta.Files, basePath, &files)
+
+	return files, version, nil
+}
+
+func (c *Client) walkFiles(listings []UnpkgFileListing, basePath string, files *library.Files) {
+	for _, item := range listings {
+		if item.Type == "directory" {
+			// Recursively process nested directories
+			subUrl := fmt.Sprintf("%s%s/?meta", basePath, item.Path)
+			subReq, _ := http.NewRequest("GET", subUrl, nil)
+			resp, err := http.DefaultClient.Do(subReq)
+			if err != nil {
+				continue
+			}
+
+			var subdir UnpkgMetaResponse
+			err = json.NewDecoder(resp.Body).Decode(&subdir)
+			if err != nil {
+				continue
+			}
+			resp.Body.Close()
+
+			c.walkFiles(subdir.Files, basePath, files)
+		} else {
+			// Add the file with proper typing to the list
+			*files = append(*files, library.File{
+				Type:      library.ExtractFileType(item.Path),
+				Path:      fmt.Sprintf("%s%s", basePath, strings.TrimPrefix(item.Path, "/")),
+				LocalPath: strings.TrimPrefix(item.Path, "/"),
+			})
+		}
+	}
+}
+
+// Helper to get latest version from npm registry
+func (c *Client) getLatestVersion(ctx context.Context, name string) (string, error) {
+	registryUrl := fmt.Sprintf("https://registry.npmjs.org/%s", name)
+	resp, err := http.Get(registryUrl)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var pkg struct {
+		DistTags struct {
+			Latest string `json:"latest"`
+		} `json:"dist-tags"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&pkg); err != nil {
+		return "", err
+	}
+
+	return pkg.DistTags.Latest, nil
+}

--- a/client/unpkg/unpkg_test.go
+++ b/client/unpkg/unpkg_test.go
@@ -1,4 +1,4 @@
-package jsdelivr
+package unpkg
 
 import (
 	"encoding/json"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/donseba/go-importmap
 
-go 1.22.3
+go 1.24.0

--- a/library/package.go
+++ b/library/package.go
@@ -1,6 +1,7 @@
 package library
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,10 @@ import (
 	"regexp"
 	"strings"
 )
+
+type Provider interface {
+	FetchPackageFiles(ctx context.Context, name, version string) (Files, string, error)
+}
 
 type Includes []Include
 
@@ -61,9 +66,10 @@ func (I Include) Name() string {
 }
 
 type Package struct {
-	Name    string
-	Version string
-	Require Includes // Patterns to specify which files to include
+	Name     string
+	Version  string
+	Provider Provider
+	Require  Includes // Patterns to specify which files to include
 }
 
 // CacheDir returns the cache dir for the current package, we will store all files in here


### PR DESCRIPTION
This pull request introduces several updates to improve the functionality and documentation of the `go-importmap` package. The main changes include the addition of new funding models, the setup of a Go linter workflow, and significant enhancements to the README documentation. Additionally, new CDN clients and tests have been added to support various providers.

### Enhancements to documentation:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R28): Simplified the package description, updated the features list, and added detailed usage examples. Removed outdated file structure information and added a new section on raw imports. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R81) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114-R129)

### New funding models:
* [`.github/FUNDING.yml`](diffhunk://#diff-07985fdcade0e64d11482724879a644f07879ba61b8fb6c6119e1b1902b72ae4R1-R15): Added multiple supported funding model platforms including GitHub Sponsors, Patreon, Open Collective, and more.

### Workflow improvements:
* [`.github/workflows/golangci-lint.yml`](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48R1-R56): Introduced a new GitHub Actions workflow for running `golangci-lint` on push and pull request events to ensure code quality.

### New CDN clients and tests:
* [`client/esmsh/esmsh.go`](diffhunk://#diff-9b2460be09083fb43d95e715b5d342bea85c16f6e28abfcfce9c819d71af1a61R1-R95): Added a new client for fetching package files from `esm.sh`.
* [`client/esmsh/esmsh_test.go`](diffhunk://#diff-cccc4bf1c8f7ffa4109071f982780990e77cf41c005403af71053be807d6c5f3R1-R32): Added tests for the new `esm.sh` client.
* [`client/raw/raw.go`](diffhunk://#diff-40da45996b77c419f9966ea552e5affddbcb50b38ff7892284954a25c7b220a6R5-R33): Updated the raw provider to fetch files from a given URL.
* [`client/raw/raw_test.go`](diffhunk://#diff-af164672279501cb17ab92639e54c8bd8e7d880022843dfd49cd4d75436e9717R1-R32): Added tests for the raw provider.

### Code quality improvements:
* [`client/cdnjs/cdnjs.go`](diffhunk://#diff-097fc16140c5393c45fdef27de5c8b05f2213a5644a27aac668246902eee6e4cL60-R60): Replaced `errors.New` with `fmt.Errorf` for better error messages.
* [`client/jsdelivr/jsdelivr.go`](diffhunk://#diff-ca34605cde196fa6298029a8cec223e91b033900650d6f47d77ea05157bb9435L79-R79): Replaced `errors.New` with `fmt.Errorf` for better error messages. [[1]](diffhunk://#diff-ca34605cde196fa6298029a8cec223e91b033900650d6f47d77ea05157bb9435L79-R79) [[2]](diffhunk://#diff-ca34605cde196fa6298029a8cec223e91b033900650d6f47d77ea05157bb9435L116-R116)
* [`client/cdnjs/cdnjs_test.go`](diffhunk://#diff-e1f6362226e07077d1a987a641271ffa8bbd8c4c3a95a3599e4a59ae5e7e2fb2L4-L10): Updated tests to use `t.Context()`. [[1]](diffhunk://#diff-e1f6362226e07077d1a987a641271ffa8bbd8c4c3a95a3599e4a59ae5e7e2fb2L4-L10) [[2]](diffhunk://#diff-e1f6362226e07077d1a987a641271ffa8bbd8c4c3a95a3599e4a59ae5e7e2fb2L26-R24)
* [`client/jsdelivr/jsdelivr_test.go`](diffhunk://#diff-fcfe8ecb410a08652b6b21c735282b150e7688c8674a39c5558dce6b9354b888L4-R11): Updated tests to use `t.Context()`.