### PR TITLE
feat: add jsdelivr minified versions

### DIFF
--- a/client/jsdelivr/jsdelivr.go
+++ b/client/jsdelivr/jsdelivr.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/donseba/go-importmap/library"
@@ -136,6 +137,8 @@ func (c *Client) FetchPackageFiles(ctx context.Context, name, version string) (l
 
 func walkFiles(files Files, basePath string, filePath string, dist bool) library.Files {
 	var f library.Files
+	cssJsRe := regexp.MustCompile(`(\.js$|\.css$)`)
+	minRe := regexp.MustCompile(`(\.min\.js$|\.min\.css$)`)
 	for _, file := range files {
 		if file.Type == "directory" {
 			if dist && file.Name == "dist" {
@@ -152,6 +155,15 @@ func walkFiles(files Files, basePath string, filePath string, dist bool) library
 			Path:      basePath + filePath + file.Name,
 			LocalPath: filePath + file.Name,
 		})
+		if cssJsRe.Match([]byte(file.Name)) {
+			if !minRe.Match([]byte(file.Name)) {
+				f = append(f, library.File{
+					Type:      library.ExtractFileType(file.Name),
+					Path:      basePath + filePath + library.FileNameMin(file.Name),
+					LocalPath: filePath + library.FileNameMin(file.Name),
+				})
+			}
+		}
 	}
 
 	return f

--- a/client/jsdelivr/jsdelivr_test.go
+++ b/client/jsdelivr/jsdelivr_test.go
@@ -30,3 +30,20 @@ func TestNew(t *testing.T) {
 
 	t.Log(string(out))
 }
+
+func TestIncludeMinified(t *testing.T) {
+	cdn := New()
+
+	f, _, err := cdn.FetchPackageFiles(t.Context(), "@hotwired/turbo", "8.0.13")
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if len(f) != 4 {
+		t.Error("files count mismatch")
+	}
+
+	t.Log(f)
+}

--- a/library/files.go
+++ b/library/files.go
@@ -1,6 +1,9 @@
 package library
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"regexp"
+)
 
 const (
 	// FileTypeJS represents a JavaScript file
@@ -30,4 +33,17 @@ func ExtractFileType(filename string) FileType {
 	default:
 		return FileTypeOther
 	}
+}
+
+func FileNameMin(filename string) string {
+	jsRe := regexp.MustCompile(`\.js$`)
+	cssRe := regexp.MustCompile(`\.css$`)
+	if ExtractFileType(filename) == FileTypeJS {
+		filename = jsRe.ReplaceAllString(filename, ".min.js")
+	}
+	if ExtractFileType(filename) == FileTypeCSS {
+		filename = cssRe.ReplaceAllString(filename, ".min.css")
+	}
+
+	return filename
 }


### PR DESCRIPTION
This pull request enhances the functionality of the `client/jsdelivr` package by adding support for identifying and including minified versions of `.js` and `.css` files. It also introduces corresponding tests to ensure correctness. The changes primarily focus on extending file handling logic and updating the library utilities.

### Enhancements to file handling:

* [`client/jsdelivr/jsdelivr.go`](diffhunk://#diff-ca34605cde196fa6298029a8cec223e91b033900650d6f47d77ea05157bb9435R8): Added regex patterns to identify `.js` and `.css` files and their minified counterparts (`.min.js` and `.min.css`). Updated the `walkFiles` function to include minified file paths for `.js` and `.css` files when they are not already present. [[1]](diffhunk://#diff-ca34605cde196fa6298029a8cec223e91b033900650d6f47d77ea05157bb9435R8) [[2]](diffhunk://#diff-ca34605cde196fa6298029a8cec223e91b033900650d6f47d77ea05157bb9435R140-R141) [[3]](diffhunk://#diff-ca34605cde196fa6298029a8cec223e91b033900650d6f47d77ea05157bb9435R158-R166)
* [`library/files.go`](diffhunk://#diff-f6a16322f2d1157c47e9db3c0d287eb1046f4a8bf57f128cc5d8863ee0daf01cR37-R49): Introduced the `FileNameMin` function to generate the minified file names for `.js` and `.css` files based on their original names.

### Test coverage:

* [`client/jsdelivr/jsdelivr_test.go`](diffhunk://#diff-fcfe8ecb410a08652b6b21c735282b150e7688c8674a39c5558dce6b9354b888R33-R49): Added a new test, `TestIncludeMinified`, to verify that the `FetchPackageFiles` function correctly includes minified file versions for a sample package.