### PR TITLE
jsdelivr esm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,33 @@ results in generating:
     {"imports":{"htmx":"https://unpkg.com/browse/htmx.org@1.8.6/dist/htmx.min.js"}}
 ```
 
+### jsdelivr ESM imports can be fetched using the jsdelivr provider:
+
+```go
+  im := importmap.
+    NewDefaults().
+    WithProvider(cdnjs.New()).
+    AssetsDir(path.Join("assets")).
+    WithPackages([]library.Package{
+    {
+      Name:    "htmx",
+      Version: "2.0.4",
+      Require: []library.Include{
+        {File: "htmx.esm.min.js"},
+        {File: "/ext/json-enc.js", As: "json-enc"},
+	  },
+	},{
+      Provider: jsdelivr.NewESM(), // <!-- Use jsdelivr ESM provider -->
+      Name:     "@simonwep/pickr",
+      Version:  "1.9.1",
+      Require: []library.Include{
+        {File: "/esm-bundle.js", As: "pickr"}, // <!-- Get the ESM bundle -->
+        {File: "/dist/themes/nano.min.css", As: "nano.min.css"},
+	  },
+	},
+  })
+```
+
 ## Contributing
 
 Contributions are welcome!


### PR DESCRIPTION
This pull request introduces support for ESM (ECMAScript Module) imports via the jsdelivr provider, enhancing the flexibility of package file handling. The changes include updates to the `README.md` to document the new functionality, modifications to the `Client` struct to support ESM mode, and adjustments to the file-fetching logic to accommodate ESM-specific behavior.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R134-R160): Added an example demonstrating how to use the jsdelivr provider with ESM imports, including configuration for specific packages and files.

### ESM Support in `jsdelivr` Client:
* [`client/jsdelivr/jsdelivr.go`](diffhunk://#diff-ca34605cde196fa6298029a8cec223e91b033900650d6f47d77ea05157bb9435R22): Added an `esm` field to the `Client` struct to track ESM mode.
* [`client/jsdelivr/jsdelivr.go`](diffhunk://#diff-ca34605cde196fa6298029a8cec223e91b033900650d6f47d77ea05157bb9435R62-R81): Introduced a `NewESM` function to create a client with ESM mode enabled, and a `SetESM` method to toggle ESM mode dynamically.

### File Fetching Enhancements:
* [`client/jsdelivr/jsdelivr.go`](diffhunk://#diff-ca34605cde196fa6298029a8cec223e91b033900650d6f47d77ea05157bb9435R152-R175): Updated the `FetchPackageFiles` method to include logic for handling ESM imports. When ESM mode is enabled, JavaScript files are replaced with an ESM bundle, while non-JS files (e.g., CSS) are preserved.