### PR TITLE
fix typo

### DIFF
--- a/client/jsdelivr/jsdelivr.go
+++ b/client/jsdelivr/jsdelivr.go
@@ -158,7 +158,7 @@ func (c *Client) FetchPackageFiles(ctx context.Context, name, version string) (l
 		esmFile := library.File{
 			Type:      library.FileTypeJS,
 			Path:      esmBasePath,
-			LocalPath: "/esm-bundle.js", // Simple filename without special characters
+			LocalPath: "esm-bundle.js", // Simple filename without special characters
 		}
 
 		// Filter out JavaScript files, keeping only CSS and other files


### PR DESCRIPTION
This pull request includes a minor change to the `FetchPackageFiles` method in `client/jsdelivr/jsdelivr.go`. The change removes a leading slash from the `LocalPath` value for the `esmFile` object, simplifying the file path.

* [`client/jsdelivr/jsdelivr.go`](diffhunk://#diff-ca34605cde196fa6298029a8cec223e91b033900650d6f47d77ea05157bb9435L161-R161): Updated the `LocalPath` for the `esmFile` object from `"/esm-bundle.js"` to `"esm-bundle.js"`, removing the leading slash.